### PR TITLE
Add `w` alias in

### DIFF
--- a/Essentials/src/plugin.yml
+++ b/Essentials/src/plugin.yml
@@ -186,7 +186,7 @@ commands:
   msg:
     description: Sends a private message to the specified player.
     usage: /<command> <to> <message>
-    aliases: [m,t,emsg,tell,etell,whisper,ewhisper]
+    aliases: [m,t,emsg,tell,etell,whisper,ewhisper,w]
   mute:
     description: Mutes or unmutes a player.
     usage: /<command> [player] <datediff>


### PR DESCRIPTION
Way back when `/w` used to be an alias for `/msg` on servers; i keep mistyping it half the time, so this PR fixes that.