### PR TITLE
Fix /realname

### DIFF
--- a/Essentials/src/main/java/com/earth2me/essentials/commands/Commandrealname.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/commands/Commandrealname.java
@@ -17,19 +17,19 @@ public class Commandrealname extends EssentialsCommand {
         if (args.length < 1) {
             throw new NotEnoughArgumentsException();
         }
+        int found = 0;
         final String whois = args[0].toLowerCase();
         for (Player p : server.getOnlinePlayers()) {
             final User u = ess.getUser(p);
             if (u.isHidden()) {
                 continue;
             }
-            final String displayName = ChatColor.stripColor(u.getDisplayName()).toLowerCase();
-            if (!whois.equals(displayName)
-                    && !displayName.equals(ChatColor.stripColor(ess.getSettings().getNicknamePrefix()) + whois)
-                    && !whois.equalsIgnoreCase(u.getName())) {
-                continue;
-            }
+            final String displayName =
+                    u.getNickname() == null ? u.getName().toLowerCase() : u.getNickname().replaceAll("&([0-9a-f])", "").toLowerCase();
+            if (!whois.equals(displayName) && !whois.equalsIgnoreCase(u.getName())) continue;
             user.sendMessage(u.getDisplayName() + " " + Util.i18n("is") + " " + u.getName());
+            found++;
         }
+        if(found == 0) user.sendMessage(ChatColor.DARK_RED + "Could not a user with the nickname " + ChatColor.DARK_BLUE + args[0]);
     }
 }

--- a/Essentials/src/main/java/com/earth2me/essentials/commands/Commandrealname.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/commands/Commandrealname.java
@@ -30,6 +30,6 @@ public class Commandrealname extends EssentialsCommand {
             user.sendMessage(u.getDisplayName() + " " + Util.i18n("is") + " " + u.getName());
             found++;
         }
-        if(found == 0) user.sendMessage(ChatColor.DARK_RED + "Could not a user with the nickname " + ChatColor.DARK_BLUE + args[0]);
+        if(found == 0) user.sendMessage(ChatColor.DARK_RED + "Could not find a user with the nickname " + ChatColor.DARK_BLUE + args[0]);
     }
 }


### PR DESCRIPTION
When EssentialsChat is installed, you have to type
/realname [Rank]~Nickname
to get the real name of a user. If no user was found, the command provides no feedback.

I fixed this, you now only have to type
/realname Nickname
and the command now notifies you if no user was found.