### PR TITLE
Update plugin.yml

### DIFF
--- a/Essentials/src/main/resources/plugin.yml
+++ b/Essentials/src/main/resources/plugin.yml
@@ -196,7 +196,7 @@ commands:
   msg:
     description: Sends a private message to the specified player.
     usage: /<command> <to> <message>
-    aliases: [m,t,emsg,tell,etell,whisper,ewhisper,w]
+    aliases: [m,t,emsg,tell,etell,whisper,ewhisper]
   mute:
     description: Mutes or unmutes a player.
     usage: /<command> [player] <datediff>

--- a/Essentials/src/main/resources/plugin.yml
+++ b/Essentials/src/main/resources/plugin.yml
@@ -196,7 +196,7 @@ commands:
   msg:
     description: Sends a private message to the specified player.
     usage: /<command> <to> <message>
-    aliases: [m,t,emsg,tell,etell,whisper,ewhisper]
+    aliases: [m,t,emsg,tell]
   mute:
     description: Mutes or unmutes a player.
     usage: /<command> [player] <datediff>


### PR DESCRIPTION
Removes /w allias to prevent /socialspy evasion in game.

/w and its following string seem to be removed entirely instead of just removing the command when printing to the user with social spy enabled.