### PR TITLE
Update Plugin.yml allias'

### DIFF
--- a/Essentials/src/main/resources/plugin.yml
+++ b/Essentials/src/main/resources/plugin.yml
@@ -196,7 +196,7 @@ commands:
   msg:
     description: Sends a private message to the specified player.
     usage: /<command> <to> <message>
-    aliases: [m,t,emsg,tell,etell,whisper,ewhisper,w]
+    aliases: [m,t,emsg,tell,etell,whisper,ewhisper]
   mute:
     description: Mutes or unmutes a player.
     usage: /<command> [player] <datediff>

--- a/Essentials/src/main/resources/plugin.yml
+++ b/Essentials/src/main/resources/plugin.yml
@@ -196,7 +196,7 @@ commands:
   msg:
     description: Sends a private message to the specified player.
     usage: /<command> <to> <message>
-    aliases: [m,t,emsg,tell,etell,whisper,ewhisper]
+    aliases: [m,t,emsg,tell]
   mute:
     description: Mutes or unmutes a player.
     usage: /<command> [player] <datediff>


### PR DESCRIPTION
Updates plugin.yml allias' for all commands not being picked up and printed by the social spy command listener.

This stops social spy evasion in game as a temporary stop gap solution.
See https://github.com/retromcorg/Essentials/pull/12 for more info.

