### PR TITLE
Update build-and-test.yaml to actually produce jar files

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -1,4 +1,3 @@
----
 name: build-and-test
 on:
   pull_request:
@@ -23,20 +22,28 @@ jobs:
         uses: actions/setup-java@v2
         with:
           distribution: 'temurin'
-          java-version: 21
+          java-version: 8
 
       - name: Set up Maven
         uses: stCarolas/setup-maven@v4.5
         with:
           maven-version: 3.9.1
 
-      - name: build application
+      - name: Build application
         shell: bash
         run: |
           mvn clean install
-
-      - name: Upload artifact
+      - name: Upload JAR files from all modules
         uses: actions/upload-artifact@v4
         with:
-          name: JVillage
-          path: target/*.jar
+          name: ${{ github.event.repository.name }}-${{ github.sha }}
+          path: |
+            Essentials/target/*.jar
+            EssentialsChat/target/*.jar
+            EssentialsGeoIP/target/*.jar
+            EssentialsGroupBadge/target/*.jar
+            EssentialsGroupManager/target/*.jar
+            EssentialsPermissionsCommands/target/*.jar
+            EssentialsProtect/target/*.jar
+            EssentialsSpawn/target/*.jar
+            EssentialsXMPP/target/*.jar


### PR DESCRIPTION
For some reason, this file was trying to produce a jar named JVillage and was not using any specific path to pull jars from. It was also using Java 21, which is not something this repo supports.