### PR TITLE
unsilence maven build log

### DIFF
--- a/Build.bat
+++ b/Build.bat
@@ -1,2 +1,2 @@
-cmd /c "mvn clean package -q"
+cmd /c "mvn clean package"
 python collect_and_rename.py


### PR DESCRIPTION
The Build.bat file executes maven with the quiet flag. This can be annoying when the build fails.