### PR TITLE
make the player list easier to read with a new color scheme

### DIFF
--- a/Essentials/src/main/java/com/earth2me/essentials/commands/Commandlist.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/commands/Commandlist.java
@@ -108,11 +108,14 @@ public class Commandlist extends EssentialsCommand {
         if (hiddenPlayerCount > 0)
             output += " " + Util.format("playersOnlineHiddenTag", hiddenPlayerCount);
 
-        output += ":\n";
+        output += ":";
         return output;
     }
 
     private String getChatFooter(int page, int totalPages) {
+        if(totalPages == 1)
+            return  Util.i18n("pageNumberDisplaySingle");
+
         return Util.format("pageNumberDisplay", page, totalPages);
     }
 
@@ -195,8 +198,8 @@ public class Commandlist extends EssentialsCommand {
         }
 
         for (User user : onlineUsers) {
-            String playerName = getPlayerString(user);
-            playerName += "\n";
+            String playerName = Util.i18n("playersOnlineListBullet") + " ";
+            playerName += getPlayerString(user);
 
             sender.sendMessage(playerName);
         }

--- a/Essentials/src/main/resources/messages.properties
+++ b/Essentials/src/main/resources/messages.properties
@@ -216,7 +216,8 @@ onlyDayNight = /time only supports day/night.
 onlyPlayers = Only in-game players can use {0}.
 onlySunStorm = /weather only supports sun/storm.
 pageIsNotAnInteger = \u00a7cPage number must be an integer!
-pageNumberDisplay = \u00a77======== [ \u00a7b{0}\u00a77/\u00a7b{1} \u00a77] ========
+pageNumberDisplay = \u00a79======== [ \u00a7e{0}\u00a76/\u00a7e{1} \u00a79] ========
+pageNumberDisplaySingle = \u00a79=======================
 pTimeCurrent = \u00a7e{0}''s\u00a7f time is {1}.
 pTimeCurrentFixed = \u00a7e{0}''s\u00a7f time is fixed to {1}.
 pTimeNormal = \u00a7e{0}''s\u00a7f time is normal and matches the server.
@@ -238,9 +239,10 @@ playerMutedFor = \u00a77You have been muted for {0}
 playerNeverOnServer = \u00a7cPlayer {0} was never on this server.
 playerNotFound = \u00a7cPlayer not found.
 playerUnmuted = \u00a77You have been unmuted
-playersOnlineMultiple = \u00a77There are \u00a7b{0} \u00a77players online
-playersOnlineSingle = \u00a77There is \u00a7b1 \u00a77player online
-playersOnlineHiddenTag = \u00a77(\u00a7d{0} hidden\u00a77)
+playersOnlineListBullet = \u00a79-
+playersOnlineMultiple = \u00a79There are \u00a7e{0} \u00a79players online
+playersOnlineSingle = \u00a79There is \u00a7e1 \u00a79player online
+playersOnlineHiddenTag = \u00a79(\u00a7d{0} hidden\u00a79)
 pong = Pong!
 possibleWorlds = \u00a77Possible worlds are the numbers 0 through {0}.
 powerToolAir = Command can''t be attached to air.


### PR DESCRIPTION
I changed the color scheme of /list to blue instead of gray for easier readability in the chat.
Also some minor bug fixes and changes
- fixed the console /list from having newlines in each list entry
- removed [1/1] page count for straight "===" bar
- each player now has a "-" before their entry to distinguish the player in the list from a chat message