### PR TITLE
Fixes /msg Bug, Simplify Logic

### DIFF
--- a/Essentials/src/main/java/com/earth2me/essentials/commands/Commandmsg.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/commands/Commandmsg.java
@@ -7,9 +7,7 @@ import com.earth2me.essentials.Util;
 import org.bukkit.Server;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
-
 import java.util.List;
-
 
 public class Commandmsg extends EssentialsCommand {
     public Commandmsg() {
@@ -30,21 +28,17 @@ public class Commandmsg extends EssentialsCommand {
         }
 
         String message = getFinalArg(args, 1);
-
         if (sender instanceof Player) {
             User user = ess.getUser(sender);
             if (user.isMuted()) {
                 throw new Exception(Util.i18n("voiceSilenced"));
             }
-
-            if (user.isAuthorized("essentials.chat.color"))
-            {
+            if (user.isAuthorized("essentials.chat.color")) {
                 message = (message.replaceAll("&([0-9a-f])", "§$1"));
             }
         }
-        
-        String translatedMe = Util.i18n("me");
 
+        String translatedMe = Util.i18n("me");
         IReplyTo replyTo = sender instanceof Player ? ess.getUser(sender) : Console.getConsoleReplyTo();
         String senderName = sender instanceof Player ? ((Player) sender).getDisplayName() : Console.NAME;
 
@@ -58,31 +52,25 @@ public class Commandmsg extends EssentialsCommand {
         }
 
         List<Player> matches = server.matchPlayer(args[0]);
-
         if (matches.isEmpty()) {
             throw new Exception(Util.i18n("playerNotFound"));
         }
 
-        int i = 0;
-        for (Player p : matches) {
-            final User u = ess.getUser(p);
-            if (u.isHidden()) {
-                i++;
-            }
-        }
-        if (i == matches.size()) {
+        Player targetPlayer = matches.get(0);
+        final User u = ess.getUser(targetPlayer);
+
+        if (u.isHidden()) {
             throw new Exception(Util.i18n("playerNotFound"));
         }
 
-        for (Player p : matches) {
-            sender.sendMessage(Util.format("msgFormat", translatedMe, p.getDisplayName(), message));
-            final User u = ess.getUser(p);
-            if (sender instanceof Player && (u.isIgnoredPlayer(((Player) sender).getName()) || u.isHidden())) {
-                continue;
-            }
-            p.sendMessage(Util.format("msgFormat", senderName, translatedMe, message));
-            replyTo.setReplyTo(ess.getUser(p));
-            ess.getUser(p).setReplyTo(sender);
+        sender.sendMessage(Util.format("msgFormat", translatedMe, targetPlayer.getDisplayName(), message));
+
+        if (sender instanceof Player && (u.isIgnoredPlayer(((Player) sender).getName()))) {
+            return;
         }
+
+        targetPlayer.sendMessage(Util.format("msgFormat", senderName, translatedMe, message));
+        replyTo.setReplyTo(ess.getUser(targetPlayer));
+        ess.getUser(targetPlayer).setReplyTo(sender);
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.earth2me.essentialss</groupId>
     <artifactId>essentials-parent</artifactId>
-    <version>2.6.8-RETROMC-SNAPSHOT</version>
+    <version>2.6.9-RETROMC-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <modules>


### PR DESCRIPTION
Fixes /msg sending messages to all users with a character in their name ie `/msg e` sends to every player with the letter _e_ in their name, Simplifies logic by instantly throwing a player not found error for hidden players. Also removes loop since we are only sending to one player now.