### PR TITLE
fix: convert color codes on getDisplayName()

### DIFF
--- a/Essentials/src/main/java/com/earth2me/essentials/PlayerWrapper.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/PlayerWrapper.java
@@ -279,7 +279,9 @@ public class PlayerWrapper implements Player {
     @Override
     public String getDisplayName() {
         if (base.getDisplayName() != null)
-            return base.getDisplayName();
+            // .replace() to allow support for color codes \u00a7 == §
+            // color codes '&[0-9a-f]' are set through display name
+            return base.getDisplayName().replace("&", "\u00a7");
         else
             return base.getName();
     }


### PR DESCRIPTION
Fundamentals was setting the DisplayName without any sort of parsing of color codes and Essentials also did not handle the color codes when needed. 

Since Essentials keeps the display name stored already changing it here ensures any presentation of the player name gets properly color parsed and the fix is applied to all current stored color coded display names.

Edit: This fix can moved up the flow but will most likely not fix existing users until they next update their nick